### PR TITLE
feat: add packaged helm chart action

### DIFF
--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -16,6 +16,9 @@ on:
           - peerdb
           - peerdb-catalog
 
+env:
+  HELM_REPO_URL: "https://peerdb-io.github.io/peerdb-enterprise"
+
 jobs:
   release-chart:
     permissions:
@@ -49,6 +52,7 @@ jobs:
           do
             test -f dest/$(helm show chart "src/${chart}" | yq '.name + "-"  +  .version + ".tgz"') && echo "Existing Chart with same version found" 2>&1 && exit 1
             echo "Updating and packaging ${chart}"
+            cp src/LICENSE.md src/${chart}/
             helm dep up "src/${chart}"
             helm package "src/${chart}" -u -d dest
           done
@@ -57,7 +61,7 @@ jobs:
         working-directory: dest
         run: |
           set -e
-          helm repo index . --url https://raw.githubusercontent.com/${{ github.repository }}/gh-pages
+          helm repo index . --url "${{ env.HELM_REPO_URL }}"
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git add $(git ls-files -o --exclude-standard)

--- a/PRODUCTION.md
+++ b/PRODUCTION.md
@@ -34,6 +34,14 @@ After following the POC guide from the [QuickStart under README.md](README.md), 
 4. The charts can be further used as subchart dependencies to include more manifests to include configuration like `ExternalSecrets`, `NetworkPolicies`, `PodSecurityPolicies`, etc.
 
 
+## Accessing the Packaged Helm Charts
+
+The Helm Charts are available via the GitHub Pages site of this repo and can be accessed via the following:
+```yaml
+name: <peerdb|peerdb-catalog>
+repository: https://peerdb-io.github.io/peerdb-enterprise
+```
+
 ## Examples of production setups
 
 Example production setups can be seen in the [`examples`](examples) directory.

--- a/examples/production-with-gitops/peerdb-enterprise-catalog/.helmignore
+++ b/examples/production-with-gitops/peerdb-enterprise-catalog/.helmignore
@@ -21,3 +21,4 @@
 .idea/
 *.tmproj
 .vscode/
+LICENSE.md

--- a/examples/production-with-gitops/peerdb-enterprise-catalog/Chart.yaml
+++ b/examples/production-with-gitops/peerdb-enterprise-catalog/Chart.yaml
@@ -25,6 +25,6 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: peerdb-catalog
-    version: 0.5.0
-    repository: https://raw.githubusercontent.com/Peerdb-io/enterprise/gh-pages
+    version: 0.6.0
+    repository: https://peerdb-io.github.io/peerdb-enterprise
     alias: catalog

--- a/examples/production-with-gitops/peerdb-enterprise/.helmignore
+++ b/examples/production-with-gitops/peerdb-enterprise/.helmignore
@@ -21,3 +21,4 @@
 .idea/
 *.tmproj
 .vscode/
+LICENSE.md

--- a/examples/production-with-gitops/peerdb-enterprise/Chart.yaml
+++ b/examples/production-with-gitops/peerdb-enterprise/Chart.yaml
@@ -25,5 +25,5 @@ appVersion: "1.16.0"
 
 dependencies:
   - name: peerdb
-    version: 0.5.0
-    repository: https://raw.githubusercontent.com/Peerdb-io/enterprise/gh-pages
+    version: 0.6.0
+    repository: https://peerdb-io.github.io/peerdb-enterprise


### PR DESCRIPTION
Fixes #6 

Checklist:

* [ ] Bumped the chart version(s) according to semantic versioning
  * [ ] Bump up both `peerdb` and `peerdb-catalog` charts to the same version 
* [ ] Update `peerdb-catalog/values.yaml`:
  * [ ] Set `temporal.admintools.image.tag` pointing to version with correct value from the dependency in `peerdb/Chart.yaml` subdependency
