### PR TITLE
feat: upgrade peerdb version

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -27,7 +27,7 @@ TEMPORAL_SSL_MODE=false # Should be false if using in-cluster catalog, set true 
 
 # PEERDB SETTINGS
 # env variables for peerdb deployment
-PEERDB_VERSION=stable-v0.12.2
+PEERDB_VERSION=stable-v0.19.1
 # name of the database that will be used by peerdb.
 PEERDB_CATALOG_DATABASE=peerdb_catalog_db
 PEERDB_CATALOG_CREDS_SECRET_NAME=catalog-db-manual-creds

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/norwoodj/helm-docs
+    rev: v1.14.2
+    hooks:
+      - id: helm-docs-container
+        name: helm-docs
+        args:
+          - --chart-search-root=.
+          - --chart-to-generate=peerdb,peerdb-catalog

--- a/peerdb-catalog/Chart.yaml
+++ b/peerdb-catalog/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/peerdb-catalog/README.md
+++ b/peerdb-catalog/README.md
@@ -1,6 +1,6 @@
 # peerdb-catalog
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.12.2](https://img.shields.io/badge/AppVersion-v0.12.2-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.12.2](https://img.shields.io/badge/AppVersion-v0.12.2-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/peerdb/Chart.yaml
+++ b/peerdb/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.0
+version: 0.7.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/peerdb/README.md
+++ b/peerdb/README.md
@@ -1,6 +1,6 @@
 # peerdb
 
-![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.12.2](https://img.shields.io/badge/AppVersion-v0.12.2-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.12.2](https://img.shields.io/badge/AppVersion-v0.12.2-informational?style=flat-square)
 
 Install PeerDB along with Temporal.
 
@@ -177,7 +177,7 @@ Install PeerDB along with Temporal.
 | peerdb.service.port | int | `9900` |  |
 | peerdb.service.targetPort | int | `9900` |  |
 | peerdb.service.type | string | `"ClusterIP"` |  |
-| peerdb.version | string | `"stable-v0.12.1"` |  |
+| peerdb.version | string | `"stable-v0.19.1"` | This version is overridden by .env file if the install_peerdb.sh script is being used |
 | peerdbUI.credentials.nexauth_secret | string | `""` |  |
 | peerdbUI.credentials.password | string | `"_PEERDB_PASSWORD_"` |  |
 | peerdbUI.deployment.annotations | object | `{}` | annotations that will be applied to the peerdbUI deployment, NOT the pods |

--- a/peerdb/README.md
+++ b/peerdb/README.md
@@ -177,7 +177,7 @@ Install PeerDB along with Temporal.
 | peerdb.service.port | int | `9900` |  |
 | peerdb.service.targetPort | int | `9900` |  |
 | peerdb.service.type | string | `"ClusterIP"` |  |
-| peerdb.version | string | `"stable-v0.19.1"` | This version is overridden by .env file if the install_peerdb.sh script is being used |
+| peerdb.version | string | `"stable-v0.19.1"` | This version is overridden by .env file if the install_peerdb.sh script is being used In that case, either update the .env file or override it via values.customer.yaml when installing |
 | peerdbUI.credentials.nexauth_secret | string | `""` |  |
 | peerdbUI.credentials.password | string | `"_PEERDB_PASSWORD_"` |  |
 | peerdbUI.deployment.annotations | object | `{}` | annotations that will be applied to the peerdbUI deployment, NOT the pods |

--- a/peerdb/values.yaml
+++ b/peerdb/values.yaml
@@ -299,7 +299,8 @@ peerdb:
     # -- annotations that will be applied to the peerdb-server deployment, NOT the pods
     annotations: { }
   replicaCount: 4
-  version: stable-v0.12.1
+  # -- This version is overridden by .env file if the install_peerdb.sh script is being used
+  version: stable-v0.19.1
   image:
     repository: ghcr.io/peerdb-io/peerdb-server
     pullPolicy: Always

--- a/peerdb/values.yaml
+++ b/peerdb/values.yaml
@@ -300,6 +300,7 @@ peerdb:
     annotations: { }
   replicaCount: 4
   # -- This version is overridden by .env file if the install_peerdb.sh script is being used
+  # In that case, either update the .env file or override it via values.customer.yaml when installing
   version: stable-v0.19.1
   image:
     repository: ghcr.io/peerdb-io/peerdb-server


### PR DESCRIPTION
Checklist:

* [x] Bumped the chart version(s) according to semantic versioning
  * [x] Bump up both `peerdb` and `peerdb-catalog` charts to the same version 
* [ ] Update `peerdb-catalog/values.yaml`:
  * [ ] Set `temporal.admintools.image.tag` pointing to version with correct value from the dependency in `peerdb/Chart.yaml` subdependency
