### PR TITLE
chore(deps): upgrade peerdb version to v0.22.1

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -27,7 +27,7 @@ TEMPORAL_SSL_MODE=false # Should be false if using in-cluster catalog, set true 
 
 # PEERDB SETTINGS
 # env variables for peerdb deployment
-PEERDB_VERSION=stable-v0.19.1
+PEERDB_VERSION=stable-v0.22.1
 # name of the database that will be used by peerdb.
 PEERDB_CATALOG_DATABASE=peerdb_catalog_db
 PEERDB_CATALOG_CREDS_SECRET_NAME=catalog-db-manual-creds

--- a/peerdb-catalog/Chart.yaml
+++ b/peerdb-catalog/Chart.yaml
@@ -13,12 +13,12 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.8.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.12.2"
+appVersion: "v0.22.1"
 maintainers:
   - name: PeerDB Inc.
     url: https://peerdb.io/

--- a/peerdb-catalog/README.md
+++ b/peerdb-catalog/README.md
@@ -1,6 +1,6 @@
 # peerdb-catalog
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.12.2](https://img.shields.io/badge/AppVersion-v0.12.2-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.22.1](https://img.shields.io/badge/AppVersion-v0.22.1-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/peerdb/Chart.yaml
+++ b/peerdb/Chart.yaml
@@ -25,9 +25,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.8.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.12.2"
+appVersion: "v0.22.1"

--- a/peerdb/README.md
+++ b/peerdb/README.md
@@ -1,6 +1,6 @@
 # peerdb
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.12.2](https://img.shields.io/badge/AppVersion-v0.12.2-informational?style=flat-square)
+![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.22.1](https://img.shields.io/badge/AppVersion-v0.22.1-informational?style=flat-square)
 
 Install PeerDB along with Temporal.
 
@@ -177,7 +177,7 @@ Install PeerDB along with Temporal.
 | peerdb.service.port | int | `9900` |  |
 | peerdb.service.targetPort | int | `9900` |  |
 | peerdb.service.type | string | `"ClusterIP"` |  |
-| peerdb.version | string | `"stable-v0.19.1"` | This version is overridden by .env file if the install_peerdb.sh script is being used In that case, either update the .env file or override it via values.customer.yaml when installing |
+| peerdb.version | string | `"stable-v0.22.1"` | This version is overridden by .env file if the install_peerdb.sh script is being used In that case, either update the .env file or override it via values.customer.yaml when installing |
 | peerdbUI.credentials.nexauth_secret | string | `""` |  |
 | peerdbUI.credentials.password | string | `"_PEERDB_PASSWORD_"` |  |
 | peerdbUI.deployment.annotations | object | `{}` | annotations that will be applied to the peerdbUI deployment, NOT the pods |

--- a/peerdb/values.yaml
+++ b/peerdb/values.yaml
@@ -301,7 +301,7 @@ peerdb:
   replicaCount: 4
   # -- This version is overridden by .env file if the install_peerdb.sh script is being used
   # In that case, either update the .env file or override it via values.customer.yaml when installing
-  version: stable-v0.19.1
+  version: stable-v0.22.1
   image:
     repository: ghcr.io/peerdb-io/peerdb-server
     pullPolicy: Always


### PR DESCRIPTION
Checklist:

* [ ] Bumped the chart version(s) according to semantic versioning
  * [ ] Bump up both `peerdb` and `peerdb-catalog` charts to the same version 
* [ ] Update `peerdb-catalog/values.yaml`:
  * [ ] Set `temporal.admintools.image.tag` pointing to version with correct value from the dependency in `peerdb/Chart.yaml` subdependency
