### PR TITLE
feat(service-account): add support for extraAnnotations

### DIFF
--- a/peerdb-catalog/Chart.yaml
+++ b/peerdb-catalog/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.5
+version: 0.9.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/peerdb-catalog/README.md
+++ b/peerdb-catalog/README.md
@@ -1,6 +1,6 @@
 # peerdb-catalog
 
-![Version: 0.8.5](https://img.shields.io/badge/Version-0.8.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.30.9](https://img.shields.io/badge/AppVersion-v0.30.9-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.30.9](https://img.shields.io/badge/AppVersion-v0.30.9-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/peerdb/Chart.yaml
+++ b/peerdb/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.5
+version: 0.9.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/peerdb/README.md
+++ b/peerdb/README.md
@@ -1,6 +1,6 @@
 # peerdb
 
-![Version: 0.8.5](https://img.shields.io/badge/Version-0.8.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.30.9](https://img.shields.io/badge/AppVersion-v0.30.9-informational?style=flat-square)
+![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.30.9](https://img.shields.io/badge/AppVersion-v0.30.9-informational?style=flat-square)
 
 Install PeerDB along with Temporal.
 
@@ -219,6 +219,7 @@ Install PeerDB along with Temporal.
 | peerdbUI.version | string | `nil` | Image tag to use for PeerDB UI. To use a release version prefix with `stable-` e.g. `stable-v0.30.6`. If not present, it will fall back to the `peerdb.version` value. |
 | pyroscope.enabled | bool | `false` |  |
 | serviceAccount.create | bool | `true` |  |
+| serviceAccount.extraAnnotations | object | `{}` | Extra annotations that will be applied to the service account, e.g. for AWS IAM roles, or GCP Workload Identity |
 | serviceAccount.name | string | `nil` |  |
 | temporal-deploy.admintools.resources.limits.cpu | string | `"500m"` |  |
 | temporal-deploy.admintools.resources.limits.memory | string | `"256Mi"` |  |

--- a/peerdb/templates/service-account.yaml
+++ b/peerdb/templates/service-account.yaml
@@ -7,6 +7,9 @@ metadata:
     {{- if .Values.aws.roleArn }}
     eks.amazonaws.com/role-arn: {{ .Values.aws.roleArn }}
     {{- end }}
+    {{- with .Values.serviceAccount.extraAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   labels:
     heritage: {{ .Release.Service | quote }}
     release: {{ .Release.Name | quote }}

--- a/peerdb/values.yaml
+++ b/peerdb/values.yaml
@@ -32,6 +32,9 @@ azure:
 serviceAccount:
   create: true
   name:
+  # -- Extra annotations that will be applied to the service account, e.g. for AWS IAM roles, or GCP Workload Identity
+  extraAnnotations:
+    { }
 temporal:
   deploy:
     # -- Whether to deploy temporal, pulled from `TEMPORAL_DEPLOY_ENABLED` from .env


### PR DESCRIPTION
Checklist:

* [x] Bumped the chart version(s) according to semantic versioning
  * [x] Bump up both `peerdb` and `peerdb-catalog` charts to the same version 
* [ ] Update `peerdb-catalog/values.yaml`:
  * [ ] Set `temporal.admintools.image.tag` pointing to version with correct value from the dependency in `peerdb/Chart.yaml` subdependency
