### PR TITLE
Use existing secrets for peerdb and peerdbUI password as well as nextauth.

### DIFF
--- a/peerdb/README.md
+++ b/peerdb/README.md
@@ -154,6 +154,7 @@ Install PeerDB along with Temporal.
 | global.peerdb.lowCost.nodeSelector | object | `{}` | Node selector that will be applied to all the lowCost=true peerdb components additively |
 | global.peerdb.lowCost.tolerations | list | `[]` | Tolerations that will be applied to all the lowCost=true peerdb components additively |
 | peerdb.credentials.password | string | `"peerdb"` |  |
+| peerdb.credentials.existingSecret | string | `""` | Specify an existing Secret for the peerdb password. Secret must contain SERVER_PEERDB_PASSWORD key. Takes precedence over peerdb.credentials.password |
 | peerdb.deployment.annotations | object | `{}` | annotations that will be applied to the peerdb-server deployment, NOT the pods |
 | peerdb.deployment.labels | object | `{}` | labels that will be applied to the peerdb-server deployment, NOT the pods |
 | peerdb.enabled | bool | `true` |  |
@@ -182,7 +183,9 @@ Install PeerDB along with Temporal.
 | peerdb.service.type | string | `"ClusterIP"` |  |
 | peerdb.version | string | `"stable-v0.30.9"` | This version is overridden by .env file if the install_peerdb.sh script is being used In that case, either update the .env file or override it via values.customer.yaml when installing |
 | peerdbUI.credentials.nexauth_secret | string | `""` |  |
+| peerdbUI.credentials.nexauth_ExistingSecret | string | `""` | Specify an existing Secret for the peerdbUI nexauth secret. Secret must contain UI_NEXTAUTH_SECRET key. Takes precedence over peerdbUI.credentials.nexauth_secret |
 | peerdbUI.credentials.password | string | `"_PEERDB_PASSWORD_"` |  |
+| peerdbUI.credentials.passwordExistingSecret | string | `""` | Specify an existing Secret for the peerdbUI password. Secret must contain UI_PEERDB_PASSWORD key. Takes precedence over peerdbUI.credentials.password |
 | peerdbUI.deployment.annotations | object | `{}` | annotations that will be applied to the peerdbUI deployment, NOT the pods |
 | peerdbUI.deployment.labels | object | `{}` | labels that will be applied to the peerdbUI deployment, NOT the pods |
 | peerdbUI.enabled | bool | `true` |  |

--- a/peerdb/templates/peerdb-server-deployment.yaml
+++ b/peerdb/templates/peerdb-server-deployment.yaml
@@ -53,7 +53,11 @@ spec:
           valueFrom:
             secretKeyRef:
               key: SERVER_PEERDB_PASSWORD
+              {{- if and .Values.peerdb.credentials.password (not .Values.peerdb.credentials.existingSecret) }}
               name: peerdb-server-ui-secret
+              {{- else if .Values.peerdb.credentials.existingSecret }}
+              name: {{ .Values.peerdb.credentials.existingSecret }}
+              {{- end }}
         # flow server config
         - name: PEERDB_FLOW_SERVER_ADDRESS
           value: "http://flow-api:{{ .Values.flowApi.service.port }}"

--- a/peerdb/templates/peerdb-server-ui-secret.yaml
+++ b/peerdb/templates/peerdb-server-ui-secret.yaml
@@ -1,3 +1,4 @@
+{{- if or (and .Values.peerdbUI.credentials.password (not .Values.peerdbUI.credentials.passwordExistingSecret)) (and .Values.peerdb.credentials.password (not .Values.peerdb.credentials.existingSecret)) (not .Values.peerdbUI.credentials.nexauth_ExistingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,6 +6,13 @@ metadata:
   labels:
     {{- include "peerdb.common.labels" . | nindent 4 }}
 stringData:
+  {{- if and .Values.peerdbUI.credentials.password (not .Values.peerdbUI.credentials.passwordExistingSecret) }}
   UI_PEERDB_PASSWORD: '{{ .Values.peerdbUI.credentials.password }}'
+  {{- end }}
+  {{- if and .Values.peerdb.credentials.password (not .Values.peerdb.credentials.existingSecret) }}
   SERVER_PEERDB_PASSWORD: '{{ .Values.peerdb.credentials.password }}'
+  {{- end }}
+  {{- if not .Values.peerdbUI.credentials.nexauth_ExistingSecret }}
   UI_NEXTAUTH_SECRET: '{{ .Values.peerdbUI.credentials.nexauth_secret | default (randAlphaNum 60) }}'
+  {{- end }}
+{{- end }}

--- a/peerdb/templates/peerdb-ui-deployment.yaml
+++ b/peerdb/templates/peerdb-ui-deployment.yaml
@@ -57,12 +57,20 @@ spec:
           valueFrom:
             secretKeyRef:
               key: UI_PEERDB_PASSWORD
+              {{- if and .Values.peerdbUI.credentials.password (not .Values.peerdbUI.credentials.passwordExistingSecret) }}
               name: peerdb-server-ui-secret
+              {{- else if .Values.peerdbUI.credentials.passwordExistingSecret }}
+              name: {{ .Values.peerdbUI.credentials.passwordExistingSecret }}
+              {{- end }}
         - name: NEXTAUTH_SECRET
           valueFrom:
             secretKeyRef:
               key: UI_NEXTAUTH_SECRET
+              {{- if not .Values.peerdbUI.credentials.nexauth_ExistingSecret }}
               name: peerdb-server-ui-secret
+              {{- else }}
+              name: {{ .Values.peerdbUI.credentials.nexauth_ExistingSecret }}
+              {{- end }}
         - name: NEXTAUTH_URL
           value: {{ .Values.peerdbUI.service.url }}
         {{- with .Values.peerdbUI.extraEnv -}}

--- a/peerdb/values.yaml
+++ b/peerdb/values.yaml
@@ -205,7 +205,11 @@ peerdbUI:
   enabled: true
   credentials:
     password: _PEERDB_PASSWORD_
+    # If specified, password above is ignored. Must have UI_PEERDB_PASSWORD key.
+    # passwordExistingSecret: pw-existing-secret-name
     nexauth_secret: ''
+    # If specified, nexauth_secret is ignored. Must have UI_NEXTAUTH_SECRET key. 
+    # nexauth_ExistingSecret: na-existing-secret-name
   extraEnv: []
   lowCost: true
   pods:
@@ -316,6 +320,8 @@ peerdb:
     logDir: "/var/log/peerdb"
   credentials:
     password: "peerdb"
+    # If specified, password above is ignored. Must have SERVER_PEERDB_PASSWORD key.
+    # existingSecret: existing-secret-name
   resources:
     requests:
       cpu: 0.1
@@ -571,7 +577,7 @@ temporal-deploy:
       enabled: false
 datadog:
   # -- Whether to deploy datadog, pulled from `DATADOG_ENABLED` from .env
-  enabled: _DATADOG_ENABLED_
+  enabled: false #_DATADOG_ENABLED_
   datadog:
     containerExclude: "kube_namespace:.*"
     containerInclude: "kube_namespace:_PEERDB_K8S_NAMESPACE_"


### PR DESCRIPTION
Checklist:

* [ ] Bumped the chart version(s) according to semantic versioning
  * [ ] Bump up both `peerdb` and `peerdb-catalog` charts to the same version 
* [ ] Update `peerdb-catalog/values.yaml`:
  * [ ] Set `temporal.admintools.image.tag` pointing to version with correct value from the dependency in `peerdb/Chart.yaml` subdependency
