### PR TITLE
Fix missing service account from server deployment manifest and bump version.

### DIFF
--- a/peerdb-catalog/Chart.yaml
+++ b/peerdb-catalog/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.1
+version: 0.9.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/peerdb-catalog/README.md
+++ b/peerdb-catalog/README.md
@@ -1,6 +1,6 @@
 # peerdb-catalog
 
-![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.32.3](https://img.shields.io/badge/AppVersion-v0.32.3-informational?style=flat-square)
+![Version: 0.9.2](https://img.shields.io/badge/Version-0.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.32.3](https://img.shields.io/badge/AppVersion-v0.32.3-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/peerdb/Chart.yaml
+++ b/peerdb/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.1
+version: 0.9.2
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/peerdb/README.md
+++ b/peerdb/README.md
@@ -1,6 +1,6 @@
 # peerdb
 
-![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.32.3](https://img.shields.io/badge/AppVersion-v0.32.3-informational?style=flat-square)
+![Version: 0.9.2](https://img.shields.io/badge/Version-0.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.32.3](https://img.shields.io/badge/AppVersion-v0.32.3-informational?style=flat-square)
 
 Install PeerDB along with Temporal.
 

--- a/peerdb/templates/peerdb-server-deployment.yaml
+++ b/peerdb/templates/peerdb-server-deployment.yaml
@@ -56,10 +56,10 @@ spec:
           valueFrom:
             secretKeyRef:
               key: SERVER_PEERDB_PASSWORD
-              {{- if and .Values.peerdb.credentials.password (not .Values.peerdb.credentials.existingSecret) }}
+              {{- if .Values.peerdb.credentials.passwordExistingSecret }}
+              name: {{ .Values.peerdb.credentials.passwordExistingSecret }}
+              {{- else }}
               name: peerdb-server-ui-secret
-              {{- else if .Values.peerdb.credentials.existingSecret }}
-              name: {{ .Values.peerdb.credentials.existingSecret }}
               {{- end }}
         # flow server config
         - name: PEERDB_FLOW_SERVER_ADDRESS

--- a/peerdb/templates/peerdb-server-deployment.yaml
+++ b/peerdb/templates/peerdb-server-deployment.yaml
@@ -32,6 +32,9 @@ spec:
         {{ . | toYaml | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ default 60 .Values.peerdb.terminationGracePeriodSeconds }}
       {{- include "pods.affinity" (list $ "peerdb") | nindent 6 }}
       {{- include "pods.nodeSelector" (list $ "peerdb") | nindent 6 }}
@@ -53,10 +56,10 @@ spec:
           valueFrom:
             secretKeyRef:
               key: SERVER_PEERDB_PASSWORD
-              {{- if .Values.peerdb.credentials.passwordExistingSecret }}
-              name: {{ .Values.peerdb.credentials.passwordExistingSecret }}
-              {{- else }}
+              {{- if and .Values.peerdb.credentials.password (not .Values.peerdb.credentials.existingSecret) }}
               name: peerdb-server-ui-secret
+              {{- else if .Values.peerdb.credentials.existingSecret }}
+              name: {{ .Values.peerdb.credentials.existingSecret }}
               {{- end }}
         # flow server config
         - name: PEERDB_FLOW_SERVER_ADDRESS


### PR DESCRIPTION
This PR addresses the following issue: https://github.com/PeerDB-io/peerdb-enterprise/issues/34

All we are doing here is adding the missing serviceAccountName spec to the peerdb-server-deployment manifest.


Checklist:

* [x] Bumped the chart version(s) according to semantic versioning
  * [x] Bump up both `peerdb` and `peerdb-catalog` charts to the same version 
* [ ] Update `peerdb-catalog/values.yaml`:
  * [ ] Set `temporal.admintools.image.tag` pointing to version with correct value from the dependency in `peerdb/Chart.yaml` subdependency
