### PR TITLE
feat: add topologySpreadConstraints support to pods helpers

### DIFF
--- a/peerdb/README.md
+++ b/peerdb/README.md
@@ -62,12 +62,13 @@ Install PeerDB along with Temporal.
 | catalog.pgPassword | string | `"_PG_PASSWORD_"` | catalog password - autofilled if using in-cluster catalog, else pulled from .env |
 | catalog.pgPort | string | `"_PG_PORT_"` | catalog port - autofilled if using in-cluster catalog, else pulled from .env |
 | catalog.pgUser | string | `"_PG_USER_"` | catalog user - autofilled if using in-cluster catalog, else pulled from .env |
-| common | object | `{"pods":{"affinity":{},"imagePullSecrets":[],"nodeSelector":{},"priorityClassName":"","tolerations":[]}}` | Common values for all peerdb components that will be merged with the specific component values |
+| common | object | `{"pods":{"affinity":{},"imagePullSecrets":[],"nodeSelector":{},"priorityClassName":"","tolerations":[],"topologySpreadConstraints":[]}}` | Common values for all peerdb components that will be merged with the specific component values |
 | common.pods.affinity | object | `{}` | Affinity that will be applied to all the peerdb components additively |
 | common.pods.imagePullSecrets | list | `[]` | Image pull secrets that will be applied to all the peerdb components additively |
 | common.pods.nodeSelector | object | `{}` | Node selector that will be applied to all the peerdb components additively |
 | common.pods.priorityClassName | string | `""` | Priority class name to be applied to all peerdb components (can be overridden per component) |
 | common.pods.tolerations | list | `[]` | Tolerations that will be applied to all the peerdb components additively |
+| common.pods.topologySpreadConstraints | list | `[]` | Topology spread constraints that will be applied to all the peerdb components additively |
 | datadog.clusterAgent.createPodDisruptionBudget | bool | `true` |  |
 | datadog.clusterAgent.enabled | bool | `true` |  |
 | datadog.clusterAgent.replicas | int | `2` |  |
@@ -95,6 +96,7 @@ Install PeerDB along with Temporal.
 | flowApi.pods.nodeSelector | object | `{}` |  |
 | flowApi.pods.priorityClassName | string | `""` | Priority class name for flowApi pods |
 | flowApi.pods.tolerations | list | `[]` |  |
+| flowApi.pods.topologySpreadConstraints | list | `[]` | flowApi topology spread constraints. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ |
 | flowApi.replicaCount | int | `4` |  |
 | flowApi.resources.limits.cpu | float | `0.5` |  |
 | flowApi.resources.limits.ephemeral-storage | string | `"4Gi"` |  |
@@ -122,6 +124,7 @@ Install PeerDB along with Temporal.
 | flowSnapshotWorker.pods.nodeSelector | object | `{}` |  |
 | flowSnapshotWorker.pods.priorityClassName | string | `""` | Priority class name for flowSnapshotWorker pods |
 | flowSnapshotWorker.pods.tolerations | list | `[]` |  |
+| flowSnapshotWorker.pods.topologySpreadConstraints | list | `[]` | flowSnapshotWorker topology spread constraints. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ |
 | flowSnapshotWorker.replicaCount | int | `1` |  |
 | flowSnapshotWorker.resources.limits.cpu | int | `1` |  |
 | flowSnapshotWorker.resources.limits.ephemeral-storage | string | `"16Gi"` |  |
@@ -148,6 +151,7 @@ Install PeerDB along with Temporal.
 | flowWorker.pods.nodeSelector | object | `{}` |  |
 | flowWorker.pods.priorityClassName | string | `""` | Priority class name for flowWorker pods |
 | flowWorker.pods.tolerations | list | `[]` |  |
+| flowWorker.pods.topologySpreadConstraints | list | `[]` | flowWorker topology spread constraints. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ |
 | flowWorker.replicaCount | int | `2` |  |
 | flowWorker.resources.limits.cpu | int | `4` |  |
 | flowWorker.resources.limits.ephemeral-storage | string | `"128Gi"` |  |
@@ -161,6 +165,7 @@ Install PeerDB along with Temporal.
 | global.peerdb.lowCost.nodeSelector | object | `{}` | Node selector that will be applied to all the lowCost=true peerdb components additively |
 | global.peerdb.lowCost.priorityClassName | string | `""` | Priority class name to be applied to all lowCost=true peerdb components (can be overridden per component) |
 | global.peerdb.lowCost.tolerations | list | `[]` | Tolerations that will be applied to all the lowCost=true peerdb components additively |
+| global.peerdb.lowCost.topologySpreadConstraints | list | `[]` | Topology spread constraints that will be applied to all the lowCost=true peerdb components additively |
 | peerdb.credentials.password | string | `"peerdb"` |  |
 | peerdb.credentials.passwordExistingSecret | string | `""` | Use this existing secret for PeerDB Server Password. Must have `SERVER_PEERDB_PASSWORD` key. |
 | peerdb.deployment.annotations | object | `{}` | annotations that will be applied to the peerdb-server deployment, NOT the pods |
@@ -178,6 +183,7 @@ Install PeerDB along with Temporal.
 | peerdb.pods.nodeSelector | object | `{}` |  |
 | peerdb.pods.priorityClassName | string | `""` | Priority class name for peerdb-server pods |
 | peerdb.pods.tolerations | list | `[]` |  |
+| peerdb.pods.topologySpreadConstraints | list | `[]` | peerdb-server topology spread constraints. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ |
 | peerdb.replicaCount | int | `4` |  |
 | peerdb.resources.limits.cpu | float | `0.5` |  |
 | peerdb.resources.limits.ephemeral-storage | string | `"4Gi"` |  |
@@ -218,6 +224,7 @@ Install PeerDB along with Temporal.
 | peerdbUI.pods.nodeSelector | object | `{}` |  |
 | peerdbUI.pods.priorityClassName | string | `""` | Priority class name for peerdbUI pods |
 | peerdbUI.pods.tolerations | list | `[]` |  |
+| peerdbUI.pods.topologySpreadConstraints | list | `[]` | peerdbUI topology spread constraints. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/ |
 | peerdbUI.replicaCount | int | `4` |  |
 | peerdbUI.resources.limits.cpu | float | `0.5` |  |
 | peerdbUI.resources.limits.ephemeral-storage | string | `"4Gi"` |  |

--- a/peerdb/templates/_helpers.tpl
+++ b/peerdb/templates/_helpers.tpl
@@ -311,6 +311,23 @@ spec:
 {{- end }}
 {{- end -}}
 
+{{- define "pods.topologySpreadConstraints" }}
+{{- $ := index . 0 }}
+{{- $service := index . 1 }}
+{{- $commonTopologySpread := $.Values.common.pods.topologySpreadConstraints | default list }}
+{{- $lowCostTopologySpread := list }}
+{{- if (index (index $.Values $service) "lowCost") }}
+    {{- $lowCostTopologySpread = $.Values.global.peerdb.lowCost.topologySpreadConstraints | default list }}
+{{- end }}
+{{- $specificTopologySpread := index (index (index $.Values $service) "pods") "topologySpreadConstraints" | default list }}
+{{- $combined := concat $commonTopologySpread $lowCostTopologySpread $specificTopologySpread }}
+{{- with $combined }}
+topologySpreadConstraints:
+  {{- $combined | toYaml | nindent 2 }}
+{{- end }}
+{{- end }}
+
+
 {{- define "azure.config" -}}
 {{- if .Values.azure.clientId }}
 - name: AZURE_CLIENT_ID

--- a/peerdb/templates/flow-api-deployment.yaml
+++ b/peerdb/templates/flow-api-deployment.yaml
@@ -39,6 +39,7 @@ spec:
       {{- include "pods.affinity" (list $ "flowApi") | nindent 6 }}
       {{- include "pods.nodeSelector" (list $ "flowApi") | nindent 6 }}
       {{- include "pods.tolerations" (list $ "flowApi") | nindent 6 }}
+      {{- include "pods.topologySpreadConstraints" (list $ "flowApi") | nindent 6 }}
       {{- include "pods.imagePullSecrets" (list $ "flowApi") | nindent 6 }}
       {{- include "pods.priorityClassName" (list $ "flowApi") | nindent 6 }}
 

--- a/peerdb/templates/flow-snapshot-worker-stateful-set.yaml
+++ b/peerdb/templates/flow-snapshot-worker-stateful-set.yaml
@@ -40,6 +40,7 @@ spec:
       {{- include "pods.affinity" (list $ "flowSnapshotWorker") | nindent 6 }}
       {{- include "pods.nodeSelector" (list $ "flowSnapshotWorker") | nindent 6 }}
       {{- include "pods.tolerations" (list $ "flowSnapshotWorker") | nindent 6 }}
+      {{- include "pods.topologySpreadConstraints" (list $ "flowSnapshotWorker") | nindent 6 }}
       {{- include "pods.imagePullSecrets" (list $ "flowSnapshotWorker") | nindent 6 }}
       {{- include "pods.priorityClassName" (list $ "flowSnapshotWorker") | nindent 6 }}
 

--- a/peerdb/templates/flow-worker-deployment.yaml
+++ b/peerdb/templates/flow-worker-deployment.yaml
@@ -39,6 +39,7 @@ spec:
       {{- include "pods.affinity" (list $ "flowWorker") | nindent 6 }}
       {{- include "pods.nodeSelector" (list $ "flowWorker") | nindent 6 }}
       {{- include "pods.tolerations" (list $ "flowWorker") | nindent 6 }}
+      {{- include "pods.topologySpreadConstraints" (list $ "flowWorker") | nindent 6 }}
       {{- include "pods.imagePullSecrets" (list $ "flowWorker") | nindent 6 }}
       {{- include "pods.priorityClassName" (list $ "flowWorker") | nindent 6 }}
       containers:

--- a/peerdb/templates/peerdb-server-deployment.yaml
+++ b/peerdb/templates/peerdb-server-deployment.yaml
@@ -39,6 +39,7 @@ spec:
       {{- include "pods.affinity" (list $ "peerdb") | nindent 6 }}
       {{- include "pods.nodeSelector" (list $ "peerdb") | nindent 6 }}
       {{- include "pods.tolerations" (list $ "peerdb") | nindent 6 }}
+      {{- include "pods.topologySpreadConstraints" (list $ "peerdb") | nindent 6 }}
       {{- include "pods.imagePullSecrets" (list $ "peerdb") | nindent 6 }}
       {{- include "pods.priorityClassName" (list $ "peerdb") | nindent 6 }}
       containers:

--- a/peerdb/templates/peerdb-ui-deployment.yaml
+++ b/peerdb/templates/peerdb-ui-deployment.yaml
@@ -39,6 +39,7 @@ spec:
       {{- include "pods.affinity" (list $ "peerdbUI") | nindent 6 }}
       {{- include "pods.nodeSelector" (list $ "peerdbUI") | nindent 6 }}
       {{- include "pods.tolerations" (list $ "peerdbUI") | nindent 6 }}
+      {{- include "pods.topologySpreadConstraints" (list $ "peerdbUI") | nindent 6 }}
       {{- include "pods.imagePullSecrets" (list $ "peerdbUI") | nindent 6 }}
       {{- include "pods.priorityClassName" (list $ "peerdbUI") | nindent 6 }}
 

--- a/peerdb/values.yaml
+++ b/peerdb/values.yaml
@@ -91,6 +91,8 @@ flowWorker:
                     values:
                       - flow-worker
               topologyKey: topology.kubernetes.io/zone
+    # -- flowWorker topology spread constraints. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+    topologySpreadConstraints: []
     # -- annotations that will be applied to all flowWorker pods, NOT the deployment
     annotations: {}
     # -- labels that will be applied to all flowWorker pods, NOT the deployment
@@ -130,6 +132,8 @@ flowSnapshotWorker:
     # -- Priority class name for flowSnapshotWorker pods
     priorityClassName: ""
     affinity: {}
+    # -- flowSnapshotWorker topology spread constraints. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+    topologySpreadConstraints: []
     # -- annotations that will be applied to all flowSnapshotWorker pods, NOT the statefulSet
     annotations: {}
     # -- labels that will be applied to all flowSnapshotWorker pods, NOT the statefulSet
@@ -187,6 +191,8 @@ flowApi:
                     values:
                       - flow-api
               topologyKey: topology.kubernetes.io/zone
+    # -- flowApi topology spread constraints. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+    topologySpreadConstraints: []
     # -- annotations that will be applied to all flowApi pods, NOT the deployment
     annotations: {}
     # -- labels that will be applied to all flowApi pods, NOT the deployment
@@ -253,6 +259,8 @@ peerdbUI:
                     values:
                       - peerdb-ui
               topologyKey: topology.kubernetes.io/zone
+    # -- peerdbUI topology spread constraints. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+    topologySpreadConstraints: []
     # -- annotations that will be applied to all peerdbUI pods, NOT the deployment
     annotations: {}
     # -- labels that will be applied to all peerdbUI pods, NOT the deployment
@@ -325,6 +333,8 @@ peerdb:
                     values:
                       - peerdb-server
               topologyKey: topology.kubernetes.io/zone
+    # -- peerdb-server topology spread constraints. See https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+    topologySpreadConstraints: []
     # -- annotations that will be applied to the peerdb-server pods, NOT the deployment
     annotations: {}
     # -- labels that will be applied to the peerdb-server pods, NOT the deployment
@@ -644,6 +654,8 @@ common:
     tolerations: []
     # -- Affinity that will be applied to all the peerdb components additively
     affinity: {}
+    # -- Topology spread constraints that will be applied to all the peerdb components additively
+    topologySpreadConstraints: []
     # -- Image pull secrets that will be applied to all the peerdb components additively
     imagePullSecrets: []
     # -- Priority class name to be applied to all peerdb components (can be overridden per component)
@@ -662,3 +674,5 @@ global:
       affinity: {}
       # -- Priority class name to be applied to all lowCost=true peerdb components (can be overridden per component)
       priorityClassName: ""
+      # -- Topology spread constraints that will be applied to all the lowCost=true peerdb components additively
+      topologySpreadConstraints: []


### PR DESCRIPTION
## Summary

Adds a new `pods.topologySpreadConstraints` helper to `_helpers.tpl`, mirroring the existing merge pattern used by `pods.tolerations` / `pods.imagePullSecrets`. The helper concatenates constraints from three sources:

1. `common.pods.topologySpreadConstraints`
2. `global.peerdb.lowCost.topologySpreadConstraints` (only when the component has `lowCost: true`)
3. `<component>.pods.topologySpreadConstraints`

Wired into the five workload templates that already consume the `pods.*` helpers: `flow-api`, `flow-worker`, `flow-snapshot-worker`, `peerdb-server`, `peerdb-ui`.

## Motivation

The chart already supports pod/node (anti-)affinity via `pods.affinity`, but not [`topologySpreadConstraints`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) — the modern, more expressive way to spread pods across zones/nodes.

`preferredDuringSchedulingIgnoredDuringExecution` podAntiAffinity (the chart's current default for `flowWorker`, `flowApi`, `peerdbUI`, `peerdb`) is best-effort and can pack multiple replicas into a single zone under scheduling pressure. For operators running in multi-AZ production, this is a real HA gap — losing a zone can take down all replicas of a component even when the deployment has `replicaCount >= 2`.

`requiredDuringSchedulingIgnoredDuringExecution` podAntiAffinity is an alternative, but has coarser semantics (binary "never colocate" vs. skew-balanced). `topologySpreadConstraints` lets users express `maxSkew`, `minDomains`, `whenUnsatisfiable: DoNotSchedule|ScheduleAnyway` — the full Kubernetes API surface.

Without this helper, users currently have to patch rendered manifests downstream (kustomize post-render, vendored forks, etc.). This change makes it a first-class values knob.

## Backward compatibility

Fully backward compatible. All new keys default to empty lists (`[]`), and the helper renders nothing when no constraints are set. Existing values files produce byte-identical output.

## Verification

Rendered three scenarios with `helm template`:

- **Default values** → 0 `topologySpreadConstraints:` blocks in output (no-op).
- **`common.pods.topologySpreadConstraints=[A]` + `flowWorker.pods.topologySpreadConstraints=[B]`** → both A and B appear on the flow-worker Deployment, in that order.
- **`global.peerdb.lowCost.topologySpreadConstraints=[C]`** → C appears on `flow-api`, `flow-snapshot-worker`, `peerdb-server`, `peerdb-ui` (`lowCost: true`) but NOT on `flow-worker` (`lowCost: false`).

## Files changed

- `peerdb/templates/_helpers.tpl` — new `pods.topologySpreadConstraints` helper (~15 lines, matches `pods.tolerations` shape)
- `peerdb/templates/{flow-api,flow-worker,peerdb-server,peerdb-ui}-deployment.yaml` + `peerdb/templates/flow-snapshot-worker-stateful-set.yaml` — one-line `include` each
- `peerdb/values.yaml` — documented `topologySpreadConstraints: []` on `common.pods`, `global.peerdb.lowCost`, and each per-component `pods:` block
- `peerdb/Chart.yaml` — version bump `0.9.14` → `0.9.15` (additive feature)
- `peerdb/README.md` — regenerated via `docker run -v "\$PWD:/helm-docs" -u \$(id -u) jnorwood/helm-docs:latest -c peerdb` (per the convention in #64)

## Test plan

- [x] `helm lint peerdb/` passes
- [x] `helm template peerdb/` renders identically to 0.9.14 with default values
- [x] Per-component `topologySpreadConstraints` merge with `common.pods.*`
- [x] `lowCost`-gated merge with `global.peerdb.lowCost.*`
- [x] `helm-docs` README regenerated