### PR TITLE
feat: add temporal support for existing secret

### DIFF
--- a/peerdb/README.md
+++ b/peerdb/README.md
@@ -322,6 +322,7 @@ Install PeerDB along with Temporal.
 | temporal.deploy.registerNamespace.resources.requests.cpu | float | `0.1` |  |
 | temporal.deploy.registerNamespace.resources.requests.ephemeral-storage | string | `"4Gi"` |  |
 | temporal.deploy.registerNamespace.resources.requests.memory | string | `"128Mi"` |  |
+| temporal.existingSecret | string | `""` | Use an existing secret for Temporal TLS credentials. When set, clientCert/clientKey are ignored. |
 | temporal.host | string | `"peerdb-temporal-frontend"` |  |
 | temporal.k8s_namespace | string | `"_PEERDB_TEMPORAL_K8S_NAMESPACE_"` |  |
 | temporal.namespace | string | `"default"` |  |

--- a/peerdb/README.md
+++ b/peerdb/README.md
@@ -349,6 +349,7 @@ Install PeerDB along with Temporal.
 | temporal.deploy.registerNamespace.resources.requests.cpu | float | `0.1` |  |
 | temporal.deploy.registerNamespace.resources.requests.ephemeral-storage | string | `"4Gi"` |  |
 | temporal.deploy.registerNamespace.resources.requests.memory | string | `"128Mi"` |  |
+| temporal.existingSecret | string | `""` | Use an existing secret for Temporal TLS credentials. When set, clientCert/clientKey are ignored. |
 | temporal.host | string | `"peerdb-temporal-frontend"` |  |
 | temporal.k8s_namespace | string | `"_PEERDB_TEMPORAL_K8S_NAMESPACE_"` |  |
 | temporal.namespace | string | `"default"` |  |

--- a/peerdb/templates/_helpers.tpl
+++ b/peerdb/templates/_helpers.tpl
@@ -63,12 +63,24 @@
   value: {{ .Values.temporal.host }}:{{ .Values.temporal.port }}
 - name: PEERDB_TEMPORAL_NAMESPACE
   value: {{ .Values.temporal.namespace }}
-
 {{- if not .Values.temporal.deploy.enabled }}
+{{- if .Values.temporal.existingSecret }}
+- name: TEMPORAL_CLIENT_CERT
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.temporal.existingSecret }}
+      key: tls.crt
+- name: TEMPORAL_CLIENT_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.temporal.existingSecret }}
+      key: tls.key
+{{- else }}
 - name: TEMPORAL_CLIENT_CERT
   value: {{ .Values.temporal.clientCert }}
 - name: TEMPORAL_CLIENT_KEY
   value: {{ .Values.temporal.clientKey }}
+{{- end }}
 {{- end }}
 - name: PEERDB_DEPLOYMENT_UID
   value: {{ .Values.temporal.taskQueueId }}

--- a/peerdb/templates/_helpers.tpl
+++ b/peerdb/templates/_helpers.tpl
@@ -63,8 +63,19 @@
   value: {{ .Values.temporal.host }}:{{ .Values.temporal.port }}
 - name: PEERDB_TEMPORAL_NAMESPACE
   value: {{ .Values.temporal.namespace }}
-
 {{- if not .Values.temporal.deploy.enabled }}
+{{- if .Values.temporal.existingSecret }}
+- name: TEMPORAL_CLIENT_CERT
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.temporal.existingSecret }}
+      key: tls.crt
+- name: TEMPORAL_CLIENT_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.temporal.existingSecret }}
+      key: tls.key
+{{- else }}
 {{- with .Values.temporal.tlsServerName }}
 - name: TEMPORAL_TLS_SERVER_NAME
   value: {{ . | quote }}
@@ -73,6 +84,7 @@
   value: {{ .Values.temporal.clientCert }}
 - name: TEMPORAL_CLIENT_KEY
   value: {{ .Values.temporal.clientKey }}
+{{- end }}
 {{- end }}
 - name: PEERDB_DEPLOYMENT_UID
   value: {{ .Values.temporal.taskQueueId }}

--- a/peerdb/values.yaml
+++ b/peerdb/values.yaml
@@ -66,6 +66,8 @@ temporal:
   releaseName: _PEERDB_TEMPORAL_RELEASE_NAME_
   clientCert: _PEERDB_TEMPORAL_CLIENT_CERT_
   clientKey: _PEERDB_TEMPORAL_CLIENT_KEY_
+  # -- Use an existing secret for Temporal TLS credentials. When set, clientCert/clientKey are ignored.
+  existingSecret: ""
   taskQueueId: _PEERDB_DEPLOYMENT_UID_
 pyroscope:
   enabled: false

--- a/peerdb/values.yaml
+++ b/peerdb/values.yaml
@@ -66,6 +66,8 @@ temporal:
   releaseName: _PEERDB_TEMPORAL_RELEASE_NAME_
   clientCert: _PEERDB_TEMPORAL_CLIENT_CERT_
   clientKey: _PEERDB_TEMPORAL_CLIENT_KEY_
+  # -- Use an existing secret for Temporal TLS credentials. When set, clientCert/clientKey are ignored.
+  existingSecret: ""
   tlsServerName: ""
   taskQueueId: _PEERDB_DEPLOYMENT_UID_
 pyroscope:


### PR DESCRIPTION
## Summary

Add support for sourcing the Temporal client TLS cert/key from an existing Kubernetes Secret via `secretKeyRef`, as an alternative to inlining the content in `temporal.clientCert` / `temporal.clientKey`.

## Motivation

When `temporal.deploy.enabled: false` (external Temporal, e.g. Temporal Cloud or a server reached over a VPC endpoint), the flow components need mTLS credentials. Today the chart renders these as plain `value:` env vars, which means:

- PEM material has to live in `values.yaml` or be injected via `--set`/`--set-file`/`install_peerdb.sh`.
- It lands in rendered manifests and inside the `customer-values-peerdb` Secret in plaintext.
- Users managing secrets with Vault, ESO, or sealed-secrets can't wire them up without post-render patching.

## Change

New optional `temporal.existingSecret` value (default `""`, fully backward-compatible), mirrors the existing `catalog.existingSecret` pattern already used for catalog credentials.
When set and `temporal.deploy.enabled: false`, the `temporal.config` helper renders `TEMPORAL_CLIENT_CERT` / `TEMPORAL_CLIENT_KEY` via `valueFrom.secretKeyRef` against that secret, using the standard `kubernetes.io/tls` keys `tls.crt` and `tls.key`. When unset, behaviour is unchanged.

```yaml
temporal:
  deploy:
    enabled: false
  existingSecret: my-temporal-tls
```

## Verification

Rendered `helm template` in the three relevant modes against `flow-api`, `flow-worker`, and `flow-snapshot-worker`:

**`existingSecret` set** → `secretKeyRef` on all three workloads:

```yaml
- name: TEMPORAL_CLIENT_CERT
  valueFrom:
    secretKeyRef:
      name: my-temporal-tls
      key: tls.crt
- name: TEMPORAL_CLIENT_KEY
  valueFrom:
    secretKeyRef:
      name: my-temporal-tls
      key: tls.key
```

**`existingSecret` empty** → inline values, no regression:

```yaml
- name: TEMPORAL_CLIENT_CERT
  value: _PEERDB_TEMPORAL_CLIENT_CERT_
- name: TEMPORAL_CLIENT_KEY
  value: _PEERDB_TEMPORAL_CLIENT_KEY_
```

**`temporal.deploy.enabled: true`** → neither `TEMPORAL_CLIENT_CERT` nor `TEMPORAL_CLIENT_KEY` rendered (unchanged).