### PR TITLE
feat: support existingSecret and tlsServerName for Temporal client TLS

### DIFF
--- a/peerdb-catalog/Chart.yaml
+++ b/peerdb-catalog/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.14
+version: 0.9.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/peerdb/Chart.yaml
+++ b/peerdb/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.14
+version: 0.9.15
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/peerdb/templates/_helpers.tpl
+++ b/peerdb/templates/_helpers.tpl
@@ -65,10 +65,27 @@
   value: {{ .Values.temporal.namespace }}
 
 {{- if not .Values.temporal.deploy.enabled }}
+{{- with .Values.temporal.tlsServerName }}
+- name: TEMPORAL_TLS_SERVER_NAME
+  value: {{ . | quote }}
+{{- end }}
+{{- if .Values.temporal.existingSecret }}
+- name: TEMPORAL_CLIENT_CERT
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.temporal.existingSecret }}
+      key: tls.crt
+- name: TEMPORAL_CLIENT_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.temporal.existingSecret }}
+      key: tls.key
+{{- else }}
 - name: TEMPORAL_CLIENT_CERT
   value: {{ .Values.temporal.clientCert }}
 - name: TEMPORAL_CLIENT_KEY
   value: {{ .Values.temporal.clientKey }}
+{{- end }}
 {{- end }}
 - name: PEERDB_DEPLOYMENT_UID
   value: {{ .Values.temporal.taskQueueId }}

--- a/peerdb/values.yaml
+++ b/peerdb/values.yaml
@@ -66,6 +66,29 @@ temporal:
   releaseName: _PEERDB_TEMPORAL_RELEASE_NAME_
   clientCert: _PEERDB_TEMPORAL_CLIENT_CERT_
   clientKey: _PEERDB_TEMPORAL_CLIENT_KEY_
+  # -- Use an existing secret for Temporal client TLS cert/key. When set
+  # (and `temporal.deploy.enabled` is false), TEMPORAL_CLIENT_CERT and
+  # TEMPORAL_CLIENT_KEY are sourced via `secretKeyRef` from this secret
+  # (keys `tls.crt` and `tls.key`) instead of inline `clientCert` /
+  # `clientKey`. Preferred when you don't want PEM material to land in
+  # rendered manifests or the customer-values Secret.
+  #
+  # NOTE: flow-api/worker expects these env vars as base64-encoded PEM
+  # strings (see `flow/internal/env.go`). Populate the secret's `tls.crt`
+  # and `tls.key` with the *base64-encoded* cert/key contents (not raw
+  # PEM); this intentionally differs from the `kubernetes.io/tls`
+  # convention, which stores raw PEM.
+  existingSecret: ""
+  # -- Override SNI / hostname verification used by the Temporal gRPC
+  # client's TLS handshake. When empty, Go's TLS stack falls back to the
+  # hostname portion of `temporal.host`. Set this when `temporal.host`
+  # differs from the hostname the server's certificate is issued for —
+  # e.g. reaching Temporal Cloud via an AWS PrivateLink VPC endpoint
+  # (`vpce-*.vpce.amazonaws.com`), whose hostname does not match the
+  # namespace wildcard cert (`*.<account>.tmprl.cloud`). Emitted as
+  # TEMPORAL_TLS_SERVER_NAME to flow-api / flow-worker /
+  # flow-snapshot-worker.
+  tlsServerName: ""
   taskQueueId: _PEERDB_DEPLOYMENT_UID_
 pyroscope:
   enabled: false


### PR DESCRIPTION
## Summary

Add two optional values under `temporal` that are threaded through the `temporal.config` helper into the flow components, covering two common Temporal Cloud gotchas that currently require chart forks or post-render patches.

```yaml
temporal:
  deploy:
    enabled: false
  existingSecret: my-temporal-tls
  tlsServerName: my-ns.my-account.tmprl.cloud
```

Both default to `""` — existing installs are unaffected.

## Motivation

### `temporal.existingSecret`

Today, when `temporal.deploy.enabled: false`, `TEMPORAL_CLIENT_CERT` / `TEMPORAL_CLIENT_KEY` can only be populated from inline `clientCert` / `clientKey`. That forces PEM material into `values.yaml` (or into `--set-file` / the `install_peerdb.sh` flow) and ultimately into the rendered manifests and the `customer-values-peerdb` Secret.

Operators who keep secrets in Vault / ESO / sealed-secrets can't wire them up today. `extraEnv` with a duplicate `name:` does **not** work — Kubernetes collapses duplicate env entries by the `name` merge key on apply (first wins), so the helper's inline entry keeps winning and the `valueFrom`-backed override is silently dropped. The rendered deployment ends up with a single entry per env name that has neither `value` nor `valueFrom`.

This mirrors the existing `catalog.existingSecret` pattern the chart already uses for catalog credentials.

### `temporal.tlsServerName`

Upstream peerdb (`flow/cmd/cert.go`) builds `tls.Config` without setting `ServerName`, so Go's TLS stack derives SNI and hostname verification from the dial address. That works for direct Temporal Cloud, but breaks when `temporal.host` doesn't match the server cert — the canonical case being Temporal Cloud reached via an AWS PrivateLink VPC endpoint:

- `temporal.host` is the VPCE hostname (`vpce-XXXX.vpce-svc-YYYY.<region>.vpce.amazonaws.com`).
- Temporal Cloud serves `*.<account>.tmprl.cloud`.
- Client sends SNI = VPCE hostname → Temporal's frontend closes the handshake:

```
unable to create Temporal client: failed reaching server: connection error:
desc = "transport: authentication handshake failed: read: connection reset by peer"
```

I'm adding the reader for this env var upstream in [PeerDB-io/peerdb#4215](https://github.com/PeerDB-io/peerdb/pull/4215). This helm change exposes it as a value and emits `TEMPORAL_TLS_SERVER_NAME` to the flow components once that lands. Setting it here before that peerdb PR merges is harmless — the flow binaries will just ignore an unknown env var.

## Change

- **`peerdb/templates/_helpers.tpl`**: `temporal.config` now emits `TEMPORAL_TLS_SERVER_NAME` (when `tlsServerName` is non-empty) and branches between inline `value:` and `valueFrom: secretKeyRef` based on `existingSecret`.
- **`peerdb/values.yaml`**: new `temporal.existingSecret` and `temporal.tlsServerName` (both `""` by default) with inline documentation, including the base64-PEM caveat for `existingSecret`.
- **`peerdb/Chart.yaml` / `peerdb-catalog/Chart.yaml`**: bump both to `0.9.15` per PR template.

## Verification

Rendered with `helm template` against `flow-api` (same helper covers `flow-worker` and `flow-snapshot-worker`) in three modes:

- **Defaults** (neither value set): output unchanged — inline `value: _PEERDB_TEMPORAL_CLIENT_CERT_`, no `TEMPORAL_TLS_SERVER_NAME`.
- **`tlsServerName` only**: emits `TEMPORAL_TLS_SERVER_NAME` alongside existing inline cert/key envs.
- **`existingSecret` + `tlsServerName`**: emits `TEMPORAL_TLS_SERVER_NAME` and swaps the cert/key entries to `valueFrom.secretKeyRef` pointing at the referenced secret.

## Checklist

- [x] Bumped the chart version(s) according to semantic versioning
  - [x] Bump up both `peerdb` and `peerdb-catalog` charts to the same version (`0.9.14` → `0.9.15`)
- [x] Update `peerdb-catalog/values.yaml`:
  - [x] Set `temporal.admintools.image.tag` pointing to version with correct value from the dependency in `peerdb/Chart.yaml` subdependency — _N/A, this PR does not bump the `temporal` subchart._

## Related

- peerdb: [PeerDB-io/peerdb#4215](https://github.com/PeerDB-io/peerdb/pull/4215) — adds `TEMPORAL_TLS_SERVER_NAME` support to the Go client.