### PR TITLE
fix: render resources on schema job containers

### DIFF
--- a/peerdb-catalog/README.md
+++ b/peerdb-catalog/README.md
@@ -71,6 +71,10 @@ A Helm chart for Kubernetes
 | pgo.resources.controller.requests.memory | string | `"512Mi"` |  |
 | pgo.singleNamespace | bool | `true` |  |
 | schema.create.enabled | bool | `true` |  |
+| schema.create.initContainerResources.limits.cpu | int | `1` |  |
+| schema.create.initContainerResources.limits.memory | string | `"1Gi"` |  |
+| schema.create.initContainerResources.requests.cpu | float | `0.5` |  |
+| schema.create.initContainerResources.requests.memory | string | `"512Mi"` |  |
 | schema.create.resources.limits.cpu | float | `0.5` |  |
 | schema.create.resources.limits.memory | string | `"512Mi"` |  |
 | schema.create.resources.requests.cpu | float | `0.5` |  |

--- a/peerdb-catalog/templates/setup-catalog-schema-jobs.yaml
+++ b/peerdb-catalog/templates/setup-catalog-schema-jobs.yaml
@@ -101,15 +101,15 @@ spec:
             - mountPath: /mounted/ca-file
               name: db-ssl-certificate
           {{- end }}
-        {{- end }}
-          {{- with .Values.schema.resources }}
+          {{- with $.Values.schema.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.schema.containerSecurityContext }}
+          {{- with $.Values.schema.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- end }}
       containers:
         {{- range $store := (list "default" "visibility") }}
         {{- $storeConfig := index $credentialStore $store }}
@@ -160,15 +160,15 @@ spec:
             - mountPath: /mounted/ca-file
               name: db-ssl-certificate
           {{- end }}
-        {{- end }}
-          {{- with .Values.schema.resources }}
+          {{- with $.Values.schema.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.schema.containerSecurityContext }}
+          {{- with $.Values.schema.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- end }}
       {{- if $temporalValues.tls.enabled }}
       volumes:
         - name: db-ssl-certificate
@@ -303,15 +303,15 @@ spec:
             - mountPath: /mounted/ca-file
               name: db-ssl-certificate
           {{- end }}
-        {{- end }}
-          {{- with .Values.schema.resources }}
+          {{- with $.Values.schema.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.schema.containerSecurityContext }}
+          {{- with $.Values.schema.containerSecurityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- end }}
       {{- if $temporalValues.tls.enabled }}
       volumes:
         - name: db-ssl-certificate

--- a/peerdb-catalog/templates/setup-postgres-job.yaml
+++ b/peerdb-catalog/templates/setup-postgres-job.yaml
@@ -67,6 +67,10 @@ spec:
               name: "go-source-files"
             - mountPath: "/build"
               name: "go-build-files"
+          {{- with .Values.schema.create.initContainerResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       containers:
         - name: "temporal-schema-create"
           image: "{{ .Values.schema.setup.pods.schemaCreate.repository }}:{{ .Values.schema.setup.pods.schemaCreate.tag }}"

--- a/peerdb-catalog/values.yaml
+++ b/peerdb-catalog/values.yaml
@@ -85,6 +85,13 @@ schema:
       limits:
         cpu: 0.5
         memory: 512Mi
+    initContainerResources:
+      requests:
+        cpu: 0.5
+        memory: 512Mi
+      limits:
+        cpu: 1
+        memory: 1Gi
   setup:
     hook:
       enabled: false


### PR DESCRIPTION
Closes #75

## Problem

In `peerdb-catalog/templates/setup-catalog-schema-jobs.yaml`, the
`{{- with .Values.schema.resources }}` and
`{{- with .Values.schema.containerSecurityContext }}` blocks are placed
**outside** the `{{- range $store := (list "default" "visibility") }}` loop
in three locations. YAML indentation makes the rendered fields silently
attach to whichever container the loop emitted last, leaving
`*-default-schema` containers without `resources` or `securityContext`.
See #75 for context and a reproduction.

There is one more install-time gap in the same chart: when
`schema.create.enabled=true` and `deploy.enabled=false`, the
`temporal-schema-create` Job renders a `go-build` initContainer from
`peerdb-catalog/templates/setup-postgres-job.yaml` without any `resources`
block. Clusters that enforce CPU/memory limits can reject that fresh-install
Job before any Pod is created.

## Fix

Move both `{{- with ... }}` blocks **inside** the range body so each
container in the loop receives them. Switch to `$.Values.schema.*` because
inside `range`, dot is rebound to the iteration value (a plain string),
so root-context access has to go through `$`. This matches how the
existing template captures `$temporalValues` and `$credentialStore` at
file scope.

Also add a new `schema.create.initContainerResources` value and render it
onto the `temporal-schema-create` Job's `go-build` initContainer. This keeps
the chart compliant for the external catalog / `deploy.enabled=false` install
path without changing the existing `schema.create.resources` value that
applies to the main `temporal-schema-create` container.

## Verification

Rendered the chart with `.Values.schema.resources`,
`.Values.schema.containerSecurityContext`, and
`.Values.schema.create.initContainerResources` set to non-empty values.

**Before** (main):

| Resource | Container | resources.limits | securityContext |
|---|---|---|---|
| temporal-schema-setup | `setup-default-schema` | ❌ | ❌ |
| temporal-schema-setup | `setup-visibility-schema` | ✅ | ✅ |
| temporal-schema-setup | `update-default-schema` | ❌ | ❌ |
| temporal-schema-setup | `update-visibility-schema` | ✅ | ✅ |
| temporal-schema-update | `update-default-schema` | ❌ | ❌ |
| temporal-schema-update | `update-visibility-schema` | ✅ | ✅ |
| temporal-schema-create | `go-build` initContainer | ❌ | N/A |

**After** (this PR):

| Resource | Container | resources.limits | securityContext |
|---|---|---|---|
| temporal-schema-setup | `setup-default-schema` | ✅ | ✅ |
| temporal-schema-setup | `setup-visibility-schema` | ✅ | ✅ |
| temporal-schema-setup | `update-default-schema` | ✅ | ✅ |
| temporal-schema-setup | `update-visibility-schema` | ✅ | ✅ |
| temporal-schema-update | `update-default-schema` | ✅ | ✅ |
| temporal-schema-update | `update-visibility-schema` | ✅ | ✅ |
| temporal-schema-create | `go-build` initContainer | ✅ | N/A |

Additional local checks:

- `helm lint ./peerdb-catalog --set deploy.enabled=false`
- `helm template peerdb-catalog ./peerdb-catalog --namespace peerdb --set deploy.enabled=false --skip-tests`
- Scanned the rendered install/upgrade manifests and confirmed every
  rendered container/initContainer has `resources.limits.cpu` and
  `resources.limits.memory`.

`helm.sh/hook: test` Pods are intentionally outside this fix because they are
only created by `helm test`, not by normal `helm install` or `helm upgrade`.

## Checklist (from PR template)

- [x] Bumped the chart version(s) according to semantic versioning
  - [x] Bump up both `peerdb` and `peerdb-catalog` charts to the same version (0.9.14 -> 0.9.15)
- [x] Update `peerdb-catalog/values.yaml`
  - Added `schema.create.initContainerResources` for the schema-create `go-build` initContainer.
