### PR TITLE
fix: expose peerdb server TCP probes host

### DIFF
--- a/peerdb/Chart.yaml
+++ b/peerdb/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.17
+version: 0.9.18
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/peerdb/README.md
+++ b/peerdb/README.md
@@ -1,6 +1,6 @@
 # peerdb
 
-![Version: 0.9.17](https://img.shields.io/badge/Version-0.9.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.37.0](https://img.shields.io/badge/AppVersion-v0.37.0-informational?style=flat-square)
+![Version: 0.9.18](https://img.shields.io/badge/Version-0.9.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.37.0](https://img.shields.io/badge/AppVersion-v0.37.0-informational?style=flat-square)
 
 Install PeerDB along with Temporal.
 
@@ -213,6 +213,7 @@ Install PeerDB along with Temporal.
 | peerdb.service.port | int | `9900` |  |
 | peerdb.service.targetPort | int | `9900` |  |
 | peerdb.service.type | string | `"ClusterIP"` |  |
+| peerdb.tcpSocketProbeHost | string | `""` | TCP probe host. Leave empty to probe the Pod IP, including IPv6 Pod IPs. |
 | peerdb.version | string | `"stable-v0.37.0"` | This version is overridden by .env file if the install_peerdb.sh script is being used In that case, either update the .env file or override it via values.customer.yaml when installing |
 | peerdbUI.credentials.nexauthExistingSecret | string | `""` | Use this existing secret for nexauth_secret. Must have `UI_NEXTAUTH_SECRET` key. |
 | peerdbUI.credentials.nexauth_secret | string | `""` |  |

--- a/peerdb/templates/peerdb-server-deployment.yaml
+++ b/peerdb/templates/peerdb-server-deployment.yaml
@@ -71,6 +71,7 @@ spec:
         {{- end }}
         livenessProbe:
           tcpSocket:
+            host: {{ .Values.peerdb.tcpSocketProbeHost | quote }}
             port: api
           initialDelaySeconds: 10
           periodSeconds: 15
@@ -80,6 +81,7 @@ spec:
         # Use init-container instead: https://stackoverflow.com/questions/51079849/kubernetes-wait-for-other-pod-to-be-ready
         readinessProbe:
           tcpSocket:
+            host: {{ .Values.peerdb.tcpSocketProbeHost | quote }}
             port: api
           initialDelaySeconds: 10
           periodSeconds: 15

--- a/peerdb/values.yaml
+++ b/peerdb/values.yaml
@@ -356,6 +356,8 @@ peerdbUI:
 peerdb:
   enabled: true
   extraEnv: []
+  # -- TCP probe host. Leave empty to probe the Pod IP, including IPv6 Pod IPs.
+  tcpSocketProbeHost: ""
   lowCost: true
   pods:
     nodeSelector: {}


### PR DESCRIPTION
## Why

During deployment to the IPv6-only cluster we found out that the peerdb-server fails TCP probes with `Liveness probe failed: dial tcp 127.0.0.1:9900: connect: connection refused`.

## Summary of changes

For the `peerdb-server` container, exposes `livenessProbe.tcpSocket.host` and `readinessProbe.tcpSocket.host` into `peerdb.tcpSocketProbeHost`.

Checklist:

* [x] Bumped the chart version(s) according to semantic versioning
